### PR TITLE
Support for Certificate Subject

### DIFF
--- a/DSCClassResources/SBFarm/SBFarm.psm1
+++ b/DSCClassResources/SBFarm/SBFarm.psm1
@@ -74,7 +74,6 @@ class SBFarm : SBBase
         are providing CertificateAutoGenerationKey for auto generation of certificates.
     #>
     [DscProperty()]
-    [ValidateLength(30,100)]
     [string]
     $FarmCertificateSubject
 

--- a/DSCClassResources/SBFarm/SBFarm.psm1
+++ b/DSCClassResources/SBFarm/SBFarm.psm1
@@ -70,6 +70,15 @@ class SBFarm : SBBase
     $FarmCertificateThumbprint
 
     <#
+        Represents the subject certificate that is used for securing the certificate. Do not provide this certificate if you
+        are providing CertificateAutoGenerationKey for auto generation of certificates.
+    #>
+    [DscProperty()]
+    [ValidateLength(30,100)]
+    [string]
+    $FarmCertificateSubject
+
+    <#
         The DNS prefix (alias) that is mapped to all server farm nodes. This cmdlet is used when an administrator
         registers a server farm. The server farm node value is returned when you call the Get-SBClientConfiguration
         cmdlet to request a connection string.

--- a/DSCClassResources/SBFarm/SBFarm.psm1
+++ b/DSCClassResources/SBFarm/SBFarm.psm1
@@ -559,7 +559,6 @@ class SBFarm : SBBase
                 $CertificateThumbprint = (Get-ChildItem -Path Cert:\LocalMachine\My\ | Where-Object {$_.Subject.ToLower() -eq $CertSubject}).Thumbprint
                 if ($null -ne $CertificateThumbprint)
                 {
-                    $newSBFarmParams.Remove("FarmCertificateSubject")
                     $newSBFarmParams.FarmCertificateThumbprint = $CertificateThumbprint
                     
                     if ($null -eq $this.EncryptionCertificateThumbprint)
@@ -574,7 +573,6 @@ class SBFarm : SBBase
         {
             Write-Verbose -Message "CertificateAutoGenerationKey is present, swapping pscredential for securestring"
             $newSBFarmParams.Remove("CertificateAutoGenerationKey")
-            $newSBFarmParams.Remove("FarmCertificateSubject")
             $newSBFarmParams.Remove("FarmCertificateThumbprint")
             $newSBFarmParams.CertificateAutoGenerationKey = $this.CertificateAutoGenerationKey.Password
         }
@@ -660,6 +658,9 @@ class SBFarm : SBBase
         $newSBFarmParams.Remove("SBFarmDBConnectionStringIntegratedSecurity")
         $newSBFarmParams.Remove("SBFarmDBConnectionStringCredential")
         $newSBFarmParams.Remove("SBFarmDBConnectionStringEncrypt")
+        
+        Write-Verbose -Message "Removing FarmCertificateSubject regardless of if it was used"
+        $newSBFarmParams.Remove("FarmCertificateSubject")
 
         Write-Verbose -Message "Invoking New-SBFarm with configurable params"
         New-SBFarm @newSBFarmParams
@@ -713,6 +714,7 @@ class SBFarm : SBBase
         $setSBFarmParams.Remove("SBFarmDBConnectionStringCredential")
         $setSBFarmParams.Remove("SBFarmDBConnectionStringEncrypt")
         $setSBFarmParams.Remove("TcpPort")
+        $setSBFarmParams.Remove("FarmCertificateSubject")
 
         Write-Verbose -Message ("Invoking Stop-SBFarm prior to calling Set-SBFarm. " +
                                 "SBHost resource should re-start hosts individually.")

--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ farm is created.
   securing TLS connections.
   Do not provide this certificate if you are providing
   CertificateAutoGenerationKey for auto generation of certificates.
+* **$FarmCertificateSubject**: Represents the subject of the certificate that is used for
+  securing TLS connections.
+  Do not provide this certificate if you are providing
+  CertificateAutoGenerationKey for auto generation of certificates.
 * **FarmDNS**: The DNS prefix (alias) that is mapped to all server farm nodes.
   This cmdlet is used when an administrator registers a server farm.
   The server farm node value is returned when you call the

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ farm is created.
   securing TLS connections.
   Do not provide this certificate if you are providing
   CertificateAutoGenerationKey for auto generation of certificates.
-* **$FarmCertificateSubject**: Represents the subject of the certificate 
+* **$FarmCertificateSubject**: Represents the subject of the certificate
   that is used for securing TLS connections.
   Do not provide this certificate if you are providing
   CertificateAutoGenerationKey for auto generation of certificates.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ farm is created.
   securing TLS connections.
   Do not provide this certificate if you are providing
   CertificateAutoGenerationKey for auto generation of certificates.
-* **$FarmCertificateSubject**: Represents the subject of the certificate that is used for
-  securing TLS connections.
+* **$FarmCertificateSubject**: Represents the subject of the certificate 
+  that is used for securing TLS connections.
   Do not provide this certificate if you are providing
   CertificateAutoGenerationKey for auto generation of certificates.
 * **FarmDNS**: The DNS prefix (alias) that is mapped to all server farm nodes.

--- a/Tests/Unit/SBBase.Tests.ps1
+++ b/Tests/Unit/SBBase.Tests.ps1
@@ -112,7 +112,7 @@ try
                     $hashtable = $testSBFarm.GetDscConfigurablePropertiesAsHashtable()
 
                     # Assert
-                    $hashtable.Count | Should BeExactly 30
+                    $hashtable.Count | Should BeExactly 31
                 }
             }
         }


### PR DESCRIPTION
Adding FarmCertificateSubject as a parameter that can be provided instead of a thumbprint. There are use cases where generating a certificate as part of the same DSC configuration was possible (and potentially likely) so the thumbprint isn't known. 

The actual method used here is pretty simple but seems to work pretty well in my testing. Obviously requires that DependsOn is used to allow the certificate request to happen first.